### PR TITLE
Small change to make debugging easier.

### DIFF
--- a/libglfork.cpp
+++ b/libglfork.cpp
@@ -38,7 +38,7 @@ struct CapturedFns {
   {
     die_if(!lib || lib[0] != '/', "need absolute library path: %s\n", lib);
     handle = dlopen(lib, RTLD_LAZY);
-    die_if(!handle, "failed to load library %s\n", lib);
+    die_if(!handle, "failed to load library %s\n%s\n", lib, dlerror() );
 #define DEF_GLX_PROTO(ret, name, args, ...) name = (ret (*) args)dlsym(handle, #name);
 #include "glx-reimpl.def"
 #include "glx-dpyredir.def"


### PR DESCRIPTION
I've just added the output of dlerror() in the case of failing to open libGL.so.1

I'm having issues with Ubuntu 12.10 - it's seems there are missing files needed for nvidia's libGL.so.1 or ldconfig needs tweaking perhaps.
