### PR TITLE
fix glShaderSource gl passthru

### DIFF
--- a/gl-passthru.def
+++ b/gl-passthru.def
@@ -504,7 +504,11 @@ DEF_GLX_PROTO(void, glGetShaderiv, (GLuint shader, GLenum pname, GLint *params),
 DEF_GLX_PROTO(GLint, glGetUniformLocation, (GLuint program, const GLchar *name), program, name)
 DEF_GLX_PROTO(void, glLinkProgram, (GLuint program), program)
 //DEF_GLX_PROTO(GLvoid*, glMapBuffer, (GLenum target, GLenum access), target, access)
-DEF_GLX_PROTO(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* *string, const GLint *length), shader, count, string, length)
+#if GL_GLEXT_VERSION < 81
+	DEF_GLX_PROTO(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* *string, const GLint *length), shader, count, string, length)
+#else
+	DEF_GLX_PROTO(void, glShaderSource, (GLuint shader, GLsizei count, const GLchar* const *string, const GLint *length), shader, count, string, length)	
+#endif
 DEF_GLX_PROTO(void, glUniform1f, (GLint location, GLfloat v0), location, v0)
 DEF_GLX_PROTO(void, glUniform1i, (GLint location, GLint v0), location, v0)
 DEF_GLX_PROTO(void, glUniform2f, (GLint location, GLfloat v0, GLfloat v1), location, v0, v1)


### PR DESCRIPTION
the 3rd argument must not be 'const GLchar\* _string', because the declaration in the glext.h file is "void glShaderSource(GLuint, GLsizei, const GLchar_ const_, const GLint_)".
Using 'const GLchar\* const *' instead will fix this.

fixes #21 fully

See this compile error output for more information:

mkdir -p lib
g++ -Wall -g -DBUMBLEBEE_SOCKET='/var/run/bumblebee.socket' -DPRIMUS_SYNC='0' -DPRIMUS_VERBOSE='1' -DPRIMUS_DISPLAY=':8' -DPRIMUS_LOAD_GLOBAL='libglapi.so.0' -DPRIMUS_libGLa='/usr//nvidia-bumblebee/libGL.so.1' -DPRIMUS_libGLd='/usr//libGL.so.1' -fvisibility=hidden -fPIC -shared -Wl,-Bsymbolic -o lib/libGL.so.1 libglfork.cpp -lX11 -lpthread -lrt
libglfork.cpp:848:2: warning: #warning Enabled workarounds for applications demanding more than promised by the OpenGL ABI [-Wcpp]
In file included from libglfork.cpp:786:0:
gl-passthru.def: In function ‘void glShaderSource(GLuint, GLsizei, const GLchar**, const GLint*)’:
gl-passthru.def:507:1: error: declaration of C function ‘void glShaderSource(GLuint, GLsizei, const GLchar**, const GLint_)’ conflicts with
In file included from /usr/include/GL/gl.h:2085:0,
                 from /usr/include/GL/glx.h:45,
                 from libglfork.cpp:16:
/usr/include/GL/glext.h:6605:21: error: previous declaration ‘void glShaderSource(GLuint, GLsizei, const GLchar_ const_, const GLint_)’ here
make: **\* [lib/libGL.so.1] Error 1

v2: fixed an error made by myself
