### PR TITLE
pass any preprocessor flags defined by environment to gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ CXXFLAGS += -DPRIMUS_libGLd='"$(PRIMUS_libGLd)"'
 
 $(LIBDIR)/libGL.so.1: libglfork.cpp
 	mkdir -p $(LIBDIR)
-	$(CXX) $(CXXFLAGS) -fvisibility=hidden -fPIC -shared -Wl,-Bsymbolic -o $@ $< -lX11 -lpthread -lrt
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -fvisibility=hidden -fPIC -shared -Wl,-Bsymbolic -o $@ $< -lX11 -lpthread -lrt


### PR DESCRIPTION
On Debian/Ubuntu this effectively means that primus would be built with -D_FORTIFY_SOURCE=2.
