### PR TITLE
primus needs this variable workaround for libglvnd enabled mesa

### DIFF
--- a/primusrun
+++ b/primusrun
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# primus needs this variable workaround for libglvnd enabled mesa
+export __GLVND_DISALLOW_PATCHING=1
+
 # Readback-display synchronization method
 # 0: no sync, 1: D lags behind one frame, 2: fully synced
 # export PRIMUS_SYNC=${PRIMUS_SYNC:-0}


### PR DESCRIPTION
Hi Alexander. This workaround is needed for primusrun to continue to work in the fedora distro. May be needed for other distros also. See https://github.com/amonakov/primus/issues/193